### PR TITLE
arch: remove noextract rules

### DIFF
--- a/arch/Containerfile
+++ b/arch/Containerfile
@@ -20,7 +20,14 @@ COPY --from=builder /output /
 RUN grep "= */var" /etc/pacman.conf | sed "/= *\/var/s/.*=// ; s/ //" | xargs -n1 sh -c 'mkdir -p "/usr/lib/sysimage/$(dirname $(echo $1 | sed "s@/var/@@"))" && mv -v "$1" "/usr/lib/sysimage/$(echo "$1" | sed "s@/var/@@")"' '' && \
     sed -i -e "/= *\/var/ s/^#//" -e "s@= */var@= /usr/lib/sysimage@g" -e "/DownloadUser/d" /etc/pacman.conf
 
+# Remove NoExtract rules, otherwise no additional languages and help pages can be installed
+# See https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/pacman-conf.d-noextract.conf?ref_type=heads
+RUN sed -i 's/^[[:space:]]*NoExtract/#&/' /etc/pacman.conf
+
 RUN pacman -Syu --noconfirm
+
+# Reinstall glibc to fix missing language files due to missing in the base image
+RUN --mount=type=tmpfs,dst=/tmp --mount=type=cache,dst=/usr/lib/sysimage/cache/pacman pacman -Sy glibc --noconfirm
 
 RUN pacman -Sy --noconfirm base dracut linux linux-firmware ostree btrfs-progs e2fsprogs xfsprogs dosfstools skopeo dbus dbus-glib glib2 ostree shadow && pacman -S --clean --noconfirm
 

--- a/arch/Containerfile
+++ b/arch/Containerfile
@@ -29,7 +29,7 @@ RUN pacman -Syu --noconfirm
 # Reinstall glibc to fix missing language files due to missing in the base image
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=cache,dst=/usr/lib/sysimage/cache/pacman pacman -Sy glibc --noconfirm
 
-RUN pacman -Sy --noconfirm base dracut linux linux-firmware ostree btrfs-progs e2fsprogs xfsprogs dosfstools skopeo dbus dbus-glib glib2 ostree shadow && pacman -S --clean --noconfirm
+RUN pacman -Sy --noconfirm base dracut linux linux-firmware ostree btrfs-progs e2fsprogs xfsprogs dosfstools skopeo dbus dbus-glib glib2 ostree shadow podman && pacman -S --clean --noconfirm
 
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root \
     --mount=type=bind,from=ctx,source=/,target=/ctx \


### PR DESCRIPTION
This is a port from https://github.com/bootcrew/arch-bootc/pull/20/changes.

Fixes: https://github.com/bootcrew/mono/issues/8
