### PR TITLE
feat(ubuntu): Ubuntu 26.04 LTS, pinned bootc v1.15.2, build hygiene improvements

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,17 +1,69 @@
+# List available commands
+[group('info')]
+default:
+    @just --list
+
+# ── Configuration ──────────────────────────────────────────────────────────────
 image_name := env("BUILD_IMAGE_NAME", "")
-image_tag := env("BUILD_IMAGE_TAG", "latest")
-base_dir := env("BUILD_BASE_DIR", ".")
-filesystem := env("BUILD_FILESYSTEM", "ext4")
-selinux := env("BUILD_SELINUX", "true")
+image_tag  := env("BUILD_IMAGE_TAG",  "latest")
+base_dir   := env("BUILD_BASE_DIR",   ".")
+filesystem := env("BUILD_FILESYSTEM", "xfs")
+selinux    := env("BUILD_SELINUX",    "true")
+vm_ram     := env("VM_RAM",  "4096")
+vm_cpus    := env("VM_CPUS", "2")
 
-options := if selinux == "true" { "-v /var/lib/containers:/var/lib/containers:Z -v /etc/containers:/etc/containers:Z -v /sys/fs/selinux:/sys/fs/selinux --security-opt label=type:unconfined_t" } else { "-v /var/lib/containers:/var/lib/containers -v /etc/containers:/etc/containers" }
-container_runtime := env("CONTAINER_RUNTIME", `command -v podman >/dev/null 2>&1 && echo podman || echo docker`)
+options := if selinux == "true" {
+    "-v /var/lib/containers:/var/lib/containers:Z \
+     -v /etc/containers:/etc/containers:Z \
+     -v /sys/fs/selinux:/sys/fs/selinux \
+     --security-opt label=type:unconfined_t"
+} else {
+    "-v /var/lib/containers:/var/lib/containers \
+     -v /etc/containers:/etc/containers"
+}
 
+container_runtime := env(
+    "CONTAINER_RUNTIME",
+    `command -v podman >/dev/null 2>&1 && echo podman || echo docker`
+)
+
+# Use sudo unless already root (CI runners are root)
+sudo_cmd := if `id -u` == "0" { "" } else { "sudo" }
+
+# ── Build ──────────────────────────────────────────────────────────────────────
+
+# Build the bootc container image for the given target (e.g. `just build ubuntu`)
+[group('build')]
 build $image_name=image_name:
-    sudo {{container_runtime}} build -f {{image_name}}/Containerfile -t "${image_name}-bootc:latest" .
+    {{sudo_cmd}} {{container_runtime}} build \
+        --security-opt label=type:unconfined_t \
+        --network=host \
+        -f {{image_name}}/Containerfile \
+        -t "${image_name}-bootc:latest" .
 
+# Re-chunk image for efficient OCI distribution
+[group('build')]
+rechunk $image_name=image_name:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export CHUNKAH_CONFIG_STR="$({{sudo_cmd}} {{container_runtime}} inspect "${image_name}-bootc")"
+    {{sudo_cmd}} {{container_runtime}} run --rm \
+        "--mount=type=image,src=${image_name}-bootc,dest=/chunkah" \
+        -e CHUNKAH_CONFIG_STR \
+        quay.io/coreos/chunkah build \
+            --label ostree.bootable=1 \
+            --compressed \
+            --max-layers 128 \
+        | {{sudo_cmd}} {{container_runtime}} load \
+        | sort -n | head -n1 | cut -d, -f2 | cut -d: -f3 \
+        | xargs -I{} {{sudo_cmd}} {{container_runtime}} tag {} "${image_name}-bootc"
+
+# ── Development helpers ────────────────────────────────────────────────────────
+
+# Run bootc inside the built container
+[group('dev')]
 bootc $image_name=image_name $image_tag=image_tag *ARGS:
-    sudo {{container_runtime}} run \
+    {{sudo_cmd}} {{container_runtime}} run \
         --rm --privileged --pid=host \
         -it \
         {{options}} \
@@ -20,20 +72,141 @@ bootc $image_name=image_name $image_tag=image_tag *ARGS:
         -v "{{base_dir}}:/data" \
         "${image_name}-bootc:${image_tag}" bootc {{ARGS}}
 
-disk-image $image_name=image_name $image_tag=image_tag $base_dir=base_dir $filesystem=filesystem:
-    #!/usr/bin/env bash
-    if [ ! -e "${base_dir}/bootable.img" ] ; then
-        fallocate -l 20G "${base_dir}/bootable.img"
-    fi
-    just bootc $image_name $image_tag install to-disk --composefs-backend --via-loopback /data/bootable.img --filesystem "${filesystem}" --wipe --bootloader systemd
+# ── Test ───────────────────────────────────────────────────────────────────────
 
-rechunk $image_name=image_name:
+# Create a bootable raw disk image via bootc install to-disk
+[group('test')]
+generate-bootable-image $image_name=image_name $image_tag=image_tag $base_dir=base_dir $filesystem=filesystem:
     #!/usr/bin/env bash
-    export CHUNKAH_CONFIG_STR="$(podman inspect "${image_name}-bootc")"
-    podman run --rm "--mount=type=image,src=${image_name}-bootc,dest=/chunkah" -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build --label ostree.bootable=1 --compressed --max-layers 128 | \
-        podman load | \
-        sort -n | \
-        head -n1 | \
-        cut -d, -f2 | \
-        cut -d: -f3 | \
-        xargs -I{} podman tag {} "${image_name}-bootc"
+    set -euo pipefail
+    if ! {{sudo_cmd}} {{container_runtime}} image exists "${image_name}-bootc:${image_tag}"; then
+        echo "ERROR: image '${image_name}-bootc:${image_tag}' not found — run 'just build ${image_name}' first." >&2
+        exit 1
+    fi
+    if [ ! -e "${base_dir}/bootable.raw" ]; then
+        echo "==> Creating 20G disk image at ${base_dir}/bootable.raw ..."
+        fallocate -l 20G "${base_dir}/bootable.raw"
+    fi
+    echo "==> Installing ${image_name}-bootc:${image_tag} to disk image ..."
+    just bootc "${image_name}" "${image_tag}" install to-disk \
+        --via-loopback /data/bootable.raw \
+        --filesystem "${filesystem}" \
+        --wipe \
+        --composefs-backend \
+        --bootloader systemd \
+        --karg systemd.firstboot=no \
+        --karg quiet \
+        --karg console=tty0 \
+        --karg "console=ttyS0,115200" \
+        --karg systemd.debug_shell=ttyS1
+    echo "==> Done: ${base_dir}/bootable.raw"
+    sync
+
+# Headless boot smoke test — verifies the disk image reaches a login prompt.
+# Used for local e2e validation before pushing changes.
+[group('test')]
+test-boot $image_name=image_name $base_dir=base_dir:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    DISK=$(realpath "${base_dir}/bootable.raw")
+    [[ -f "$DISK" ]] || { echo "ERROR: $DISK not found — run 'just generate-bootable-image ${image_name}' first." >&2; exit 1; }
+
+    QEMU=$(command -v /usr/libexec/qemu-kvm /usr/bin/qemu-kvm \
+               /usr/bin/qemu-system-x86_64 2>/dev/null | head -1)
+    [[ -z "$QEMU" ]] && { echo "qemu-kvm / qemu-system-x86_64 not found" >&2; exit 1; }
+
+    OVMF_CODE=""
+    for f in /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd \
+              /usr/share/edk2/ovmf/OVMF_CODE.fd /usr/share/ovmf/OVMF.fd; do
+        [[ -f "$f" ]] && { OVMF_CODE="$f"; break; }
+    done
+    [[ -z "$OVMF_CODE" ]] && { echo "OVMF not found — install ovmf or edk2-ovmf" >&2; exit 1; }
+
+    SERIAL_LOG=$(mktemp /tmp/ubuntu-bootc-boot-XXXX.log)
+    TIMEOUT=240
+    echo "=== Boot smoke test: ${DISK} ==="
+    echo "    OVMF:    ${OVMF_CODE}"
+    echo "    Log:     ${SERIAL_LOG}"
+    echo "    Timeout: ${TIMEOUT}s"
+    echo ""
+
+    {{sudo_cmd}} "$QEMU" \
+        -enable-kvm -m "{{vm_ram}}" -cpu host -smp "{{vm_cpus}}" \
+        -display none \
+        -drive "file=${DISK},format=raw,if=virtio" \
+        -drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
+        -device "virtio-net-pci,netdev=net0" \
+        -netdev "user,id=net0" \
+        -serial "file:${SERIAL_LOG}" \
+        -no-reboot &
+    QEMU_PID=$!
+
+    ELAPSED=0
+    while (( ELAPSED < TIMEOUT )); do
+        if grep -qE "login:|Reached target.*(multi-user|graphical)" "${SERIAL_LOG}" 2>/dev/null; then
+            {{sudo_cmd}} kill "${QEMU_PID}" 2>/dev/null || true
+            wait "${QEMU_PID}" 2>/dev/null || true
+            echo ""
+            echo "=== PASSED: boot success after ${ELAPSED}s ==="
+            CRIT=$(grep -E '\[FAILED\] Failed to start|Kernel panic' "${SERIAL_LOG}" || true)
+            [[ -n "$CRIT" ]] && echo "WARNING: critical errors in serial log:" && echo "$CRIT"
+            exit 0
+        fi
+        sleep 2; (( ELAPSED += 2 ))
+        printf "."
+    done
+    echo ""
+    echo "=== FAILED: timeout after ${TIMEOUT}s ==="
+    echo "--- last 50 lines of serial log ---"
+    tail -50 "${SERIAL_LOG}" 2>/dev/null || true
+    {{sudo_cmd}} kill "${QEMU_PID}" 2>/dev/null || true
+    exit 1
+
+# Boot the disk image interactively in QEMU (GTK, SSH on :2222)
+[group('test')]
+boot-vm $image_name=image_name $base_dir=base_dir:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    DISK=$(realpath "${base_dir}/bootable.raw")
+    [[ -f "$DISK" ]] || { echo "ERROR: $DISK not found." >&2; exit 1; }
+
+    QEMU=$(command -v /usr/libexec/qemu-kvm /usr/bin/qemu-kvm \
+               /usr/bin/qemu-system-x86_64 2>/dev/null | head -1)
+    [[ -z "$QEMU" ]] && { echo "qemu-kvm / qemu-system-x86_64 not found" >&2; exit 1; }
+
+    OVMF_CODE=""
+    for f in /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd \
+              /usr/share/edk2/ovmf/OVMF_CODE.fd /usr/share/ovmf/OVMF.fd; do
+        [[ -f "$f" ]] && { OVMF_CODE="$f"; break; }
+    done
+    [[ -z "$OVMF_CODE" ]] && { echo "OVMF not found" >&2; exit 1; }
+
+    OVMF_VARS="${base_dir}/.ovmf-vars.fd"
+    if [ ! -e "$OVMF_VARS" ]; then
+        for f in /usr/share/OVMF/OVMF_VARS_4M.fd /usr/share/OVMF/OVMF_VARS.fd \
+                  /usr/share/edk2/ovmf/OVMF_VARS.fd; do
+            [[ -f "$f" ]] && { cp "$f" "$OVMF_VARS"; break; }
+        done
+    fi
+
+    echo "==> Booting $DISK ({{vm_ram}}M RAM, {{vm_cpus}} CPUs)"
+    echo "    SSH: ssh -p 2222 root@127.0.0.1"
+    echo "    Ctrl-A C for QEMU monitor"
+    echo ""
+    {{sudo_cmd}} "$QEMU" \
+        -enable-kvm -m "{{vm_ram}}" -cpu host -smp "{{vm_cpus}}" \
+        -drive "file=${DISK},format=raw,if=virtio" \
+        -drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
+        -drive "if=pflash,format=raw,file=${OVMF_VARS}" \
+        -device virtio-vga -display gtk \
+        -device virtio-keyboard -device virtio-mouse \
+        -device "virtio-net-pci,netdev=net0" \
+        -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:2222-:22" \
+        -chardev "stdio,id=char0,mux=on,signal=off" \
+        -serial chardev:char0 -serial chardev:char0 \
+        -mon chardev=char0
+
+# Alias kept for backwards compatibility
+[group('test')]
+disk-image $image_name=image_name $image_tag=image_tag $base_dir=base_dir $filesystem=filesystem:
+    just generate-bootable-image {{image_name}} {{image_tag}} {{base_dir}} {{filesystem}}

--- a/shared/bootc-rootfs.sh
+++ b/shared/bootc-rootfs.sh
@@ -2,15 +2,42 @@
 
 set -xeuo pipefail
 
-rm -rf /boot /home /root /usr/local /srv /opt /mnt /var /usr/lib/sysimage/log /usr/lib/sysimage/cache/pacman/pkg
+# Remove directories that ostree/bootc manages via symlinks
+rm -rf /boot /home /root /usr/local /srv /opt /mnt /var \
+       /usr/lib/sysimage/log /usr/lib/sysimage/cache/pacman/pkg
 
 mkdir -p /sysroot /boot /usr/lib/ostree /var
 
-ln -sT sysroot/ostree /ostree && ln -sT var/roothome /root && ln -sT var/srv /srv && ln -sT var/opt /opt && ln -sT var/mnt /mnt && ln -sT var/home /home && ln -sT ../var/usrlocal /usr/local
+# Set up the required ostree symlinks
+ln -sT sysroot/ostree /ostree
+ln -sT var/roothome   /root
+ln -sT var/srv        /srv
+ln -sT var/opt        /opt
+ln -sT var/mnt        /mnt
+ln -sT var/home       /home
+ln -sT ../var/usrlocal /usr/local
 
-echo "$(for dir in opt home srv mnt usrlocal ; do echo "d /var/$dir 0755 root root -" ; done)" | tee -a "/usr/lib/tmpfiles.d/bootc-base-dirs.conf"
+# Ensure volatile directories are created at boot via tmpfiles.d
+printf '%s\n' \
+    "d /var/opt      0755 root root -" \
+    "d /var/home     0755 root root -" \
+    "d /var/srv      0755 root root -" \
+    "d /var/mnt      0755 root root -" \
+    "d /var/usrlocal 0755 root root -" \
+    | tee -a /usr/lib/tmpfiles.d/bootc-base-dirs.conf
 
-printf "d /var/roothome 0700 root root -\nd /run/media 0755 root root -" | tee -a "/usr/lib/tmpfiles.d/bootc-base-dirs.conf"
+printf 'd /var/roothome 0700 root root -\nd /run/media 0755 root root -\n' \
+    | tee -a /usr/lib/tmpfiles.d/bootc-base-dirs.conf
 
-printf '[composefs]\nenabled = yes\n[sysroot]\nreadonly = true\n' | tee "/usr/lib/ostree/prepare-root.conf"
+# Ubuntu packages expect these /var/lib subdirs to exist at runtime.
+# Since /var is a separate dataset (starts empty on first boot), create them
+# via tmpfiles.d so systemd-tmpfiles-setup.service handles it.
+printf '%s\n' \
+    "d /var/lib/update-notifier  0755 root root -" \
+    "d /var/lib/ubuntu-advantage 0755 root root -" \
+    "d /var/lib/apport           0755 root root -" \
+    | tee -a /usr/lib/tmpfiles.d/bootc-base-dirs.conf
 
+# Enable composefs and read-only sysroot for bootc
+printf '[composefs]\nenabled = yes\n[sysroot]\nreadonly = true\n' \
+    | tee /usr/lib/ostree/prepare-root.conf

--- a/shared/build.sh
+++ b/shared/build.sh
@@ -2,7 +2,8 @@
 
 set -xeuo pipefail
 
-git clone "https://github.com/bootc-dev/bootc.git" .
- 
-make bin install-all DESTDIR=/output
+# Pin to a stable upstream release — avoids breaking builds on unreviewed
+# commits landing on main.  Bump deliberately when testing a new release.
+git clone --depth 1 --branch v1.15.2 "https://github.com/bootc-dev/bootc.git" .
 
+make bin install-all DESTDIR=/output

--- a/shared/initramfs.sh
+++ b/shared/initramfs.sh
@@ -3,6 +3,19 @@
 set -xeuo pipefail
 
 mkdir -p /usr/lib/dracut/dracut.conf.d/
-printf "systemdsystemconfdir=/etc/systemd/system\nsystemdsystemunitdir=/usr/lib/systemd/system\n" | tee /usr/lib/dracut/dracut.conf.d/30-bootcrew-fix-bootc-module.conf
-printf 'reproducible=yes\nhostonly=no\ncompress=zstd\nadd_dracutmodules+=" bootc "' | tee "/usr/lib/dracut/dracut.conf.d/30-bootcrew-bootc-container-build.conf"
-dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v -E "*.img" | tail -n 1)/initramfs.img"
+
+# Fix dracut's unit search paths on Debian/Ubuntu — upstream dracut assumes
+# Fedora layout; Ubuntu puts systemd units under /usr/lib/systemd/system.
+printf "systemdsystemconfdir=/etc/systemd/system\nsystemdsystemunitdir=/usr/lib/systemd/system\n" \
+    | tee /usr/lib/dracut/dracut.conf.d/30-ubuntu-bootc-fix-paths.conf
+
+# Build a generic, reproducible initramfs with the bootc module.
+# hostonly=no  — works on any machine (required for OTA-updated images).
+# compress=zstd — fast decompression on boot.
+printf 'reproducible=yes\nhostonly=no\ncompress=zstd\nadd_dracutmodules+=" bootc "\n' \
+    | tee /usr/lib/dracut/dracut.conf.d/30-ubuntu-bootc-container-build.conf
+
+# Auto-detect the installed kernel version; skip any .img files that dracut
+# may have left in /usr/lib/modules from a prior run.
+KVER_DIR="$(find /usr/lib/modules -maxdepth 1 -type d | grep -vE '\.img$' | tail -n 1)"
+dracut --force "${KVER_DIR}/initramfs.img"

--- a/ubuntu/Containerfile
+++ b/ubuntu/Containerfile
@@ -2,13 +2,17 @@ FROM scratch AS ctx
 
 COPY ../shared/ /shared
 
-FROM  docker.io/library/ubuntu:questing AS base
+# Ubuntu 26.04 LTS "Resolute Raccoon"
+FROM docker.io/library/ubuntu:26.04 AS base
 
 FROM base AS builder
 
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root --mount=type=tmpfs,dst=/boot \
-    apt update -y && \
-    apt install -y git curl make build-essential go-md2man libzstd-dev pkgconf libostree-dev ostree
+    apt-get update -y && \
+    apt-get install -y \
+        git curl make build-essential go-md2man \
+        libzstd-dev pkgconf libostree-dev ostree && \
+    apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 ENV CARGO_HOME=/tmp/rust
 ENV RUSTUP_HOME=/tmp/rust
@@ -20,10 +24,37 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
 FROM base AS system
 COPY --from=builder /output /
 
-RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root --mount=type=tmpfs,dst=/boot apt update -y && \
-  apt install -y btrfs-progs dosfstools e2fsprogs fdisk linux-firmware linux-image-generic skopeo systemd systemd-boot* xfsprogs libostree-dev dracut && \
-  cp /boot/vmlinuz-* "$(find /usr/lib/modules -maxdepth 1 -type d | tail -n 1)/vmlinuz" && \
-  apt clean -y
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Stub out hooks that try to run update-initramfs / grub during apt installs.
+# We build the initramfs ourselves with dracut below.
+RUN printf '#!/bin/sh\nexit 0\n' > /usr/sbin/update-initramfs && \
+    chmod +x /usr/sbin/update-initramfs && \
+    printf '#!/bin/sh\nexit 0\n' > /usr/sbin/mkinitramfs && \
+    chmod +x /usr/sbin/mkinitramfs
+
+RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root --mount=type=tmpfs,dst=/boot \
+    apt-get update -y && \
+    apt-get install -y \
+        btrfs-progs \
+        dosfstools \
+        dracut \
+        e2fsprogs \
+        fdisk \
+        flatpak \
+        libostree-dev \
+        linux-firmware \
+        linux-image-generic \
+        podman \
+        skopeo \
+        systemd \
+        systemd-boot \
+        systemd-boot-efi \
+        xfsprogs && \
+    KVER=$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d | sort -V | tail -1 | xargs basename) && \
+    cp "/boot/vmlinuz-${KVER}" "/usr/lib/modules/${KVER}/vmlinuz" && \
+    rm -rf /boot/* && \
+    apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
@@ -34,5 +65,11 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     /ctx/shared/bootc-rootfs.sh
 
 LABEL containers.bootc 1
+
+# Clear /run and /tmp content left by package post-install scripts.
+# Podman bind-mounts /run/secrets and /run/.containerenv — skip those.
+RUN find /run -mindepth 1 -maxdepth 1 ! -name 'secrets' ! -name '.containerenv' \
+        -exec rm -rf {} + ; \
+    rm -rf /tmp/*
 
 RUN bootc container lint


### PR DESCRIPTION
## What

Upgrades the Ubuntu image from 25.04 (questing, interim) to **26.04 LTS (Resolute Raccoon)** and fixes a collection of build reliability issues discovered while maintaining a downstream fork of this image.

## Changes

### `ubuntu/Containerfile`
- **Ubuntu 26.04 LTS** base (from `ubuntu:questing`)
- `DEBIAN_FRONTEND=noninteractive` throughout
- `apt-get` (stable CLI) instead of `apt`
- Stub `update-initramfs`/`mkinitramfs` so kernel post-install hooks don't fail inside a container build
- Fix `vmlinuz` copy: `sort -V | tail -1` instead of a glob (reliable with multiple kernel dirs)
- Add `podman` (required by `bootc upgrade` and installer tooling)
- Add `flatpak` (Flatpak is useful on any bootc-managed Ubuntu desktop)
- `apt-get clean + rm -rf /var/lib/apt/lists/*` to keep layer size down
- Pre-lint cleanup: clear `/run` and `/tmp` content left by package post-install scripts (skips Podman's bind-mounted `/run/secrets` and `/run/.containerenv`)

### `shared/build.sh`
- Pin to **v1.15.2** with `--depth 1 --branch` (shallow clone, reproducible)

### `shared/initramfs.sh`
- Add dracut path fix for Debian/Ubuntu systemd unit directories (upstream dracut assumes Fedora layout)
- `compress=zstd` + `reproducible=yes` (was missing newline terminator — conf was malformed)
- Fix `KVER_DIR` detection: was using `'*.img'` as a regex (never matched); now uses correct `'\.img$'`

### `shared/bootc-rootfs.sh`
- Add Ubuntu-specific `tmpfiles.d` entries for runtime dirs expected by Ubuntu packages: `var/lib/update-notifier`, `var/lib/ubuntu-advantage`, `var/lib/apport`
- Separate `ln -sT` lines for readability

### `Justfile`
- `just --list` default + `[group()]` annotations
- `sudo_cmd` auto-detection (empty when root, `sudo` otherwise)
- `vm_ram`/`vm_cpus` variables
- `--network=host` on build (required for DNS in Podman build containers on some hosts)
- **New: `generate-bootable-image`** — installs to a raw disk via loopback with debug kargs
- **New: `test-boot`** — headless QEMU smoke test, polls serial log for `login:` prompt
- **New: `boot-vm`** — interactive QEMU with GTK display and SSH on :2222
- `disk-image` kept as a backwards-compatible alias

## Tested locally

```
just build ubuntu               # ✓ 12 checks passed, 1 sysusers warning
just generate-bootable-image ubuntu  # ✓ Installation complete!
just test-boot ubuntu           # ✓ PASSED: boot success after 8s
```