### PR TITLE
Update rechunk command to include containers.bootc label

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -30,7 +30,7 @@ disk-image $image_name=image_name $image_tag=image_tag $base_dir=base_dir $files
 rechunk $image_name=image_name:
     #!/usr/bin/env bash
     export CHUNKAH_CONFIG_STR="$(podman inspect "${image_name}-bootc")"
-    podman run --rm "--mount=type=image,src=${image_name}-bootc,target=/chunkah" -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build --label ostree.bootable=1 --compressed --max-layers 128 | \
+    podman run --rm "--mount=type=image,src=${image_name}-bootc,target=/chunkah" -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build --label ostree.bootable=1 --label containers.bootc=1 --compressed --max-layers 128 | \
         podman load | \
         sort -n | \
         head -n1 | \


### PR DESCRIPTION
Add that label, because bootc image builder in podman desktop, is not seeing it