### PR TITLE
Add bcvk-based infrastructure, use for testing

### DIFF
--- a/.devcontainer/debian/devcontainer.json
+++ b/.devcontainer/debian/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "bootcrew-devenv-debian",
+  "image": "ghcr.io/bootc-dev/devenv-debian",
+  "customizations": {
+    "vscode": {
+      // Arbitrary, but most of our code is in one of these two
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "golang.Go"
+      ]
+    },
+    "devaipod": {
+      // When running under devaipod, use minimal capabilities
+      // (SYS_ADMIN, NET_ADMIN, etc.) instead of full --privileged.
+      "nestedContainers": true
+    }
+  },
+  "features": {},
+  // Use privileged mode for broad compatibility (Codespaces, Docker,
+  // stock devcontainer CLI). devaipod overrides this with tighter
+  // security via the nestedContainers customization above.
+  "privileged": true,
+  "postCreateCommand": {
+    // Our init script
+    "devenv-init": "sudo /usr/local/bin/devenv-init.sh"
+  },
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:/usr/local/cargo/bin"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "bootcrew-devenv-debian",
+  "image": "ghcr.io/bootc-dev/devenv-debian",
+  "customizations": {
+    "vscode": {
+      // Arbitrary, but most of our code is in one of these two
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "golang.Go"
+      ]
+    },
+    "devaipod": {
+      // When running under devaipod, use minimal capabilities
+      // (SYS_ADMIN, NET_ADMIN, etc.) instead of full --privileged.
+      "nestedContainers": true
+    }
+  },
+  "features": {},
+  // Use privileged mode for broad compatibility (Codespaces, Docker,
+  // stock devcontainer CLI). devaipod overrides this with tighter
+  // security via the nestedContainers customization above.
+  "privileged": true,
+  "postCreateCommand": {
+    // Our init script
+    "devenv-init": "sudo /usr/local/bin/devenv-init.sh"
+  },
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:/usr/local/cargo/bin"
+  }
+}

--- a/.devcontainer/ubuntu/devcontainer.json
+++ b/.devcontainer/ubuntu/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "bootcrew-devenv-ubuntu",
+  "image": "ghcr.io/bootc-dev/devenv-ubuntu",
+  "customizations": {
+    "vscode": {
+      // Arbitrary, but most of our code is in one of these two
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "golang.Go"
+      ]
+    },
+    "devaipod": {
+      // When running under devaipod, use minimal capabilities
+      // (SYS_ADMIN, NET_ADMIN, etc.) instead of full --privileged.
+      "nestedContainers": true
+    }
+  },
+  "features": {},
+  // Use privileged mode for broad compatibility (Codespaces, Docker,
+  // stock devcontainer CLI). devaipod overrides this with tighter
+  // security via the nestedContainers customization above.
+  "privileged": true,
+  "postCreateCommand": {
+    // Our init script
+    "devenv-init": "sudo /usr/local/bin/devenv-init.sh"
+  },
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:/usr/local/cargo/bin"
+  }
+}

--- a/.github/workflows/build-arch.yaml
+++ b/.github/workflows/build-arch.yaml
@@ -10,10 +10,12 @@ on:
     paths:
       - 'arch/**'
       - Justfile
+      - bcvk.just
   pull_request:
     paths:
       - 'arch/**'
       - Justfile
+      - bcvk.just
     branches:
       - main
   schedule:
@@ -37,3 +39,9 @@ jobs:
       platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       publish: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+  boot-test:
+    needs: build
+    uses: ./.github/workflows/reusable-boot-test.yaml
+    with:
+      image-name: arch-bootc

--- a/.github/workflows/build-debian.yaml
+++ b/.github/workflows/build-debian.yaml
@@ -10,10 +10,12 @@ on:
     paths:
       - 'debian/**'
       - Justfile
+      - bcvk.just
   pull_request:
     paths:
       - 'debian/**'
       - Justfile
+      - bcvk.just
     branches:
       - main
   schedule:
@@ -37,3 +39,9 @@ jobs:
       platforms: amd64,arm64
       rechunk: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       publish: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+  boot-test:
+    needs: build
+    uses: ./.github/workflows/reusable-boot-test.yaml
+    with:
+      image-name: debian-bootc

--- a/.github/workflows/build-opensuse.yaml
+++ b/.github/workflows/build-opensuse.yaml
@@ -10,10 +10,12 @@ on:
     paths:
       - 'opensuse/**'
       - Justfile
+      - bcvk.just
   pull_request:
     paths:
       - 'opensuse/**'
       - Justfile
+      - bcvk.just
     branches:
       - main
   schedule:
@@ -37,3 +39,9 @@ jobs:
       platforms: amd64,arm64
       rechunk: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       publish: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+  boot-test:
+    needs: build
+    uses: ./.github/workflows/reusable-boot-test.yaml
+    with:
+      image-name: opensuse-bootc

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -10,10 +10,12 @@ on:
     paths:
       - 'ubuntu/**'
       - Justfile
+      - bcvk.just
   pull_request:
     paths:
       - 'ubuntu/**'
       - Justfile
+      - bcvk.just
     branches:
       - main
   schedule:
@@ -37,3 +39,9 @@ jobs:
       platforms: amd64,arm64
       rechunk: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       publish: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+  boot-test:
+    needs: build
+    uses: ./.github/workflows/reusable-boot-test.yaml
+    with:
+      image-name: ubuntu-bootc

--- a/.github/workflows/reusable-boot-test.yaml
+++ b/.github/workflows/reusable-boot-test.yaml
@@ -1,0 +1,35 @@
+name: Boot Test
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: "Image name (e.g. debian-bootc)"
+        required: true
+        type: string
+
+jobs:
+  boot-test:
+    name: Boot test (${{ inputs.image-name }}, amd64)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Setup bootc environment
+        uses: bootc-dev/actions/bootc-ubuntu-setup@main
+        with:
+          libvirt: 'true'
+
+      - name: Build image
+        run: |
+          distro="${{ inputs.image-name }}"
+          distro="${distro%-bootc}"
+          # Build as the runner user (no sudo) so the image lands directly in
+          # user podman storage where bcvk can find it.
+          NOSUDO=1 just build "$distro"
+
+      - name: Boot test — SSH in and assert no failed units
+        run: |
+          distro="${{ inputs.image-name }}"
+          distro="${distro%-bootc}"
+          just bcvk check "$distro"

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,5 @@
+mod bcvk 'bcvk.just'
+
 image_name := env("BUILD_IMAGE_NAME", "")
 image_tag := env("BUILD_IMAGE_TAG", "latest")
 base_dir := env("BUILD_BASE_DIR", ".")
@@ -6,9 +8,14 @@ selinux := env("BUILD_SELINUX", "true")
 
 options := if selinux == "true" { "-v /var/lib/containers:/var/lib/containers:Z -v /etc/containers:/etc/containers:Z -v /sys/fs/selinux:/sys/fs/selinux --security-opt label=type:unconfined_t" } else { "-v /var/lib/containers:/var/lib/containers -v /etc/containers:/etc/containers" }
 container_runtime := env("CONTAINER_RUNTIME", `command -v podman >/dev/null 2>&1 && echo podman || echo docker`)
+sudo_prefix := if env("NOSUDO", "") == "" { "sudo " } else { "" }
+
+# Build image and run an ephemeral VM for boot testing
+test IMAGE=image_name:
+    just bcvk build-and-test {{IMAGE}}
 
 build $image_name=image_name:
-    sudo {{container_runtime}} build -f {{image_name}}/Containerfile -t "${image_name}-bootc:latest" .
+    {{sudo_prefix}}{{container_runtime}} build -f {{image_name}}/Containerfile -t "${image_name}-bootc:latest" .
 
 bootc $image_name=image_name $image_tag=image_tag *ARGS:
     sudo {{container_runtime}} run \

--- a/arch/Containerfile
+++ b/arch/Containerfile
@@ -22,7 +22,31 @@ RUN grep "= */var" /etc/pacman.conf | sed "/= *\/var/s/.*=// ; s/ //" | xargs -n
 
 RUN pacman -Syu --noconfirm
 
-RUN pacman -Sy --noconfirm base dracut linux linux-firmware ostree btrfs-progs e2fsprogs xfsprogs dosfstools skopeo dbus dbus-glib glib2 ostree shadow && pacman -S --clean --noconfirm
+RUN pacman -Sy --noconfirm base bubblewrap dracut linux linux-firmware ostree btrfs-progs e2fsprogs xfsprogs dosfstools skopeo dbus dbus-glib glib2 ostree shadow openssh && pacman -S --clean --noconfirm
+
+RUN systemctl enable systemd-networkd systemd-resolved systemd-timesyncd sshd && \
+    systemctl mask systemd-firstboot.service
+
+# Pre-configure basic system settings so the image is ready to boot without
+# interactive prompts.  machine-id is set to "uninitialized" so systemd
+# generates a unique ID on first boot; localtime must exist or systemd-firstboot
+# (if not masked) would prompt for timezone.
+RUN echo "uninitialized" > /etc/machine-id && \
+    ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+
+# Bring up any wired ethernet interface via DHCP.
+# systemd-networkd requires a .network file to manage an interface; without
+# one it silently ignores all NICs (including the QEMU virtio NIC).
+# Match by Type=ether rather than by name to catch all naming conventions
+# (ens3, enp0s3, eth0, etc.) — same approach used in composefs-rs examples.
+RUN printf '[Match]\nType=ether\n\n[Network]\nDHCP=yes\n' \
+    > /usr/lib/systemd/network/20-wired.network
+
+# Point resolv.conf at systemd-resolved's stub via tmpfiles.d so it's
+# created correctly at first boot (can't symlink during build; resolv.conf
+# is bind-mounted by the container runtime and is EBUSY).
+RUN printf 'L! /etc/resolv.conf - - - - /run/systemd/resolve/stub-resolv.conf\n' \
+    > /usr/lib/tmpfiles.d/resolv-conf.conf
 
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root \
     --mount=type=bind,from=ctx,source=/,target=/ctx \

--- a/bcvk.just
+++ b/bcvk.just
@@ -1,0 +1,65 @@
+# bcvk ephemeral VM boot testing recipes
+#
+# bubblewrap is required in each image: bootc install to-disk (which bcvk
+# runs inside the container to create the VM disk) calls bwrap internally
+# to sandbox bootupctl during bootloader setup. Same applies to both
+# ephemeral and libvirt run paths.
+
+# List available bcvk commands
+default:
+    @just --list --justfile {{justfile()}}
+
+# Run an ephemeral VM from a named image and SSH in (destroyed on exit)
+ephemeral IMAGE:
+    bcvk ephemeral run-ssh "{{IMAGE}}-bootc:latest"
+
+# Build and run ephemeral VM for a named image
+build-and-test IMAGE:
+    just build {{IMAGE}}
+    just bcvk ephemeral {{IMAGE}}
+
+# Boot ephemeral VM and verify no systemd units failed
+[group('check')]
+check IMAGE:
+    #!/bin/bash
+    set -euo pipefail
+    echo "==> Booting {{IMAGE}} and checking for failed units..."
+    failed=$(bcvk ephemeral run-ssh "{{IMAGE}}-bootc:latest" -- systemctl --failed --no-pager --no-legend)
+    printf '%s\n' "$failed"
+    if [ -n "$failed" ]; then
+        echo "FAIL: failed units detected in {{IMAGE}}" >&2
+        exit 1
+    fi
+    echo "OK: no failed units in {{IMAGE}}"
+
+# Boot persistent libvirt VM and verify no systemd units failed (also verifies SSH)
+[group('check')]
+libvirt-check IMAGE:
+    #!/bin/bash
+    set -euo pipefail
+    name="bootcrew-check-{{IMAGE}}"
+    echo "==> Booting {{IMAGE}} (libvirt) and checking for failed units..."
+    bcvk libvirt run --name "$name" --replace "{{IMAGE}}-bootc:latest"
+    failed=$(bcvk libvirt ssh "$name" -- systemctl --failed --no-pager --no-legend)
+    bcvk libvirt rm --stop --force "$name"
+    printf '%s' "$failed"
+    if [ -n "$failed" ]; then
+        echo "FAIL: failed units detected in {{IMAGE}}" >&2
+        exit 1
+    fi
+    echo "OK: no failed units in {{IMAGE}}"
+
+# Check all four distro images for failed units
+[group('check')]
+check-all:
+    just bcvk check arch
+    just bcvk check debian
+    just bcvk check opensuse
+    just bcvk check ubuntu
+
+# Run ephemeral VMs for all four distro images in sequence
+test-all:
+    just bcvk ephemeral arch
+    just bcvk ephemeral debian
+    just bcvk ephemeral opensuse
+    just bcvk ephemeral ubuntu

--- a/debian/Containerfile
+++ b/debian/Containerfile
@@ -21,9 +21,16 @@ FROM base AS system
 COPY --from=builder /output /
 
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root --mount=type=tmpfs,dst=/boot apt update -y && \
-  apt install -y btrfs-progs dosfstools e2fsprogs fdisk firmware-linux-free linux-image-generic skopeo systemd systemd-boot* xfsprogs libostree-dev && \
+  apt install -y btrfs-progs bubblewrap dosfstools e2fsprogs fdisk firmware-linux-free linux-image-generic netplan.io libnss-resolve libnss-myhostname openssh-server skopeo systemd systemd-boot* systemd-resolved xfsprogs libostree-dev && \
   cp /boot/vmlinuz-* "$(find /usr/lib/modules -maxdepth 1 -type d | tail -n 1)/vmlinuz" && \
   apt clean -y
+
+RUN systemctl enable systemd-networkd systemd-resolved ssh && \
+    printf 'L! /etc/resolv.conf - - - - /run/systemd/resolve/stub-resolv.conf\n' \
+        > /usr/lib/tmpfiles.d/resolv-conf.conf && \
+    mkdir -p /etc/netplan && \
+    printf 'network:\n  version: 2\n  ethernets:\n    all-en:\n      match:\n        name: en*\n      dhcp4: true\n      dhcp4-overrides:\n        use-domains: true\n      dhcp6: true\n      dhcp6-overrides:\n        use-domains: true\n    all-eth:\n      match:\n        name: eth*\n      dhcp4: true\n      dhcp4-overrides:\n        use-domains: true\n      dhcp6: true\n      dhcp6-overrides:\n        use-domains: true\n' > /etc/netplan/90-default.yaml && \
+    sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config || true
 
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root \
     --mount=type=bind,from=ctx,source=/,target=/ctx \

--- a/opensuse/Containerfile
+++ b/opensuse/Containerfile
@@ -16,7 +16,34 @@ FROM base AS system
 
 COPY --from=builder /output /
 
-RUN zypper install -y btrfs-progs cpio dosfstools dracut dracut e2fsprogs glib2 kernel-default kernel-firmware-all ostree skopeo systemd systemd-boot udev xfsprogs zstd libcrypto57
+RUN zypper install -y btrfs-progs bubblewrap cpio dosfstools dracut dracut e2fsprogs glib2 kernel-default kernel-firmware-all openssh ostree skopeo systemd systemd-networkd systemd-resolved systemd-boot udev xfsprogs zstd libcrypto57 chrony
+
+RUN systemctl enable systemd-networkd systemd-resolved chronyd sshd && \
+    systemctl mask systemd-firstboot.service
+
+# Pre-configure basic system settings so the image boots without interactive
+# prompts. machine-id is "uninitialized" so systemd generates a unique ID on
+# first boot; localtime already points at UTC via the /usr/etc merge below.
+RUN echo "uninitialized" > /etc/machine-id
+
+# OpenSUSE's sshd.service does not include Before/Wants=ssh-access.target
+# (that is done by systemd-ssh-generator which OpenSUSE doesn't ship). bcvk
+# waits for ssh-access.target before SSHing in, so we add a drop-in to wire
+# sshd into that target.
+RUN mkdir -p /usr/lib/systemd/system/sshd.service.d && \
+    printf '[Unit]\nBefore=ssh-access.target\nWants=ssh-access.target\n' \
+    > /usr/lib/systemd/system/sshd.service.d/10-ssh-access-target.conf
+
+# Bring up any wired ethernet interface via DHCP — same pattern as
+# composefs-rs examples, matching by Type=ether to catch all naming
+# conventions (ens3, enp0s3, eth0, etc.).
+RUN printf '[Match]\nType=ether\n\n[Network]\nDHCP=yes\n' \
+    > /usr/lib/systemd/network/20-wired.network
+
+# Point resolv.conf at systemd-resolved's stub at first boot.
+RUN printf 'L! /etc/resolv.conf - - - - /run/systemd/resolve/stub-resolv.conf\n' \
+    > /usr/lib/tmpfiles.d/resolv-conf.conf
+
 
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
@@ -26,7 +53,21 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     echo "HOME=/var/home" | tee -a "/etc/default/useradd" && \
     /ctx/shared/bootc-rootfs.sh
 
-RUN rm -rf /usr/etc
+# OpenSUSE ships vendor config in /usr/etc (e.g. sshd_config, nsswitch.conf,
+# PAM security configs). bootc requires /usr/etc to be absent, so we merge
+# /usr/etc → /etc without overwriting files already placed by packages.
+RUN cp -rn /usr/etc/. /etc/ && rm -rf /usr/etc
+
+# The OpenSUSE chrony package ships a config with the NTP pool disabled
+# (prefixed with '!'). Write a minimal working config so chronyd starts.
+RUN printf '# NTP pool — four servers for reliability\npool pool.ntp.org iburst\n\ndriftfile /var/lib/chrony/drift\nmakestep 1.0 3\nrtcsync\nntsdumpdir /var/lib/chrony\nlogdir /var/log/chrony\n' \
+    > /etc/chrony.conf
+
+# bootc-rootfs.sh removes /var entirely; chrony's service requires /var/lib/chrony
+# to exist at startup (ProtectSystem=strict, ReadWritePaths=/var/lib/chrony).
+# Create it at first boot via tmpfiles.d.
+RUN printf 'd /var/lib/chrony 0750 chrony chrony\n' \
+    >> /usr/lib/tmpfiles.d/chrony.conf
 
 LABEL containers.bootc 1
 

--- a/ubuntu/Containerfile
+++ b/ubuntu/Containerfile
@@ -21,9 +21,15 @@ FROM base AS system
 COPY --from=builder /output /
 
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root --mount=type=tmpfs,dst=/boot apt update -y && \
-  apt install -y btrfs-progs dosfstools e2fsprogs fdisk linux-firmware linux-image-generic skopeo systemd systemd-boot* xfsprogs libostree-dev dracut && \
+  apt install -y btrfs-progs bubblewrap dosfstools e2fsprogs fdisk linux-firmware linux-image-generic netplan.io openssh-server systemd-resolved chrony skopeo systemd systemd-boot* xfsprogs libostree-dev dracut && \
   cp /boot/vmlinuz-* "$(find /usr/lib/modules -maxdepth 1 -type d | tail -n 1)/vmlinuz" && \
   apt clean -y
+
+RUN systemctl enable systemd-networkd systemd-resolved ssh && \
+    printf 'L! /etc/resolv.conf - - - - /run/systemd/resolve/stub-resolv.conf\n' \
+        > /usr/lib/tmpfiles.d/resolv-conf.conf && \
+    mkdir -p /etc/netplan && \
+    printf 'network:\n  version: 2\n  ethernets:\n    all-en:\n      match:\n        name: en*\n      dhcp4: true\n    all-eth:\n      match:\n        name: eth*\n      dhcp4: true\n' > /etc/netplan/90-default.yaml
 
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root \
     --mount=type=bind,from=ctx,source=/,target=/ctx \


### PR DESCRIPTION
This fixes each image so that they are bootable w/`bcvk ephemeral`. Biggest gaps are around ensuring we have bubblewrap in the image, plus networking and SSH.

There were a surprising amount of per-distro detail bugs here (e.g. OpenSUSE's `/usr/etc`), variances in `/etc/machine-id` and so on. Plus networking - ubuntu and netplan etc.